### PR TITLE
Use Next.js's Static Site Generation (SSG)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,16 +1,30 @@
-/** @type {import('next').NextConfig} */
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+	output: "export",
 
-module.exports = {
-  async rewrites() {
-    return [
-      {
-        source: "/",
-        destination: "/home",
-      },
-      {
-        source: "/admin",
-        destination: "/admin/index.html",
-      },
-    ];
-  },
-}
+	// Optional: Change links `/me` -> `/me/` and emit `/me.html` -> `/me/index.html`
+	trailingSlash: true,
+
+	// Optional: Prevent automatic `/me` -> `/me/`, instead preserve `href`
+	skipTrailingSlashRedirect: true,
+
+	// Optional: Change the output directory `out` -> `build`
+	distDir: "build",
+
+	async rewrites() {
+		return [
+			{
+				source: "/",
+				destination: "/home",
+			},
+			{
+				source: "/admin",
+				destination: "/admin/index.html",
+			},
+		];
+	},
+};
+
+module.exports = nextConfig;


### PR DESCRIPTION
Use Next.js's Static HTML Export when building.

- https://nextjs.org/docs/app/building-your-application/deploying/static-exports

---
- Issue: https://git.chen.so/tina-next-ts/i/3abe4ffe1dfef8520cc37ef215a2d202a726f256
- Patch: https://git.chen.so/tina-next-ts/p/7299511db1ab6a26e8a0ca458d677c674e2d2549
- https://github.com/Chen-Software/tina-next-ts/pull/13