### PR TITLE
Auto merge to both `main` and `dev/main` branches

### DIFF
--- a/.github/workflows/on-content-push-creates-pr.yml
+++ b/.github/workflows/on-content-push-creates-pr.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - name: Checkout code
+    - name: Checkout `main` branch
       uses: actions/checkout@v4
       with:
         ref: main
@@ -26,8 +26,25 @@ jobs:
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v7
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
         labels: auto-pr
         title: 'Merge from `content/main` to `main`'
         body: 'This PR was automatically generated to merge from `content/main` to `main`'
-        commit-message: 'Auto-commit PR changes from `content/main`'
+        commit-message: 'Auto-commit PR changes from `content/main` to `main`'
+
+    - name: Checkout `dev/main` branch
+      uses: actions/checkout@v4
+      with:
+        ref: dev/main
+
+    - name: Reset to content/main branch
+      run: |
+        git fetch origin content/main:content/main
+        git reset --hard content/main
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v7
+      with:
+        labels: auto-pr
+        title: 'Merge from `content/main` to `dev/main`'
+        body: 'This PR was automatically generated to merge from `content/main` to `dev/main`'
+        commit-message: 'Auto-commit PR changes from `content/main` to `dev/main`'


### PR DESCRIPTION
Edit the auto PR workflow to merge from `content/main` to both `main` and `dev/main` branches.

- Issue: https://git.chen.so/tina-next-ts/i/30f29843766ef69f0681b688f8033cb369d53a03
- Patch: https://git.chen.so/tina-next-ts/p/230b76f8cc7b851108231becb21cb9be6c1b8597
- https://github.com/Chen-Software/tina-next-ts/pull/22