### PR TITLE
Force Breadcrumbs in one line with `whiteSpace="nowrap"`

### DIFF
--- a/app/components/Breadcrumbs/index.tsx
+++ b/app/components/Breadcrumbs/index.tsx
@@ -6,11 +6,11 @@ export const Breadcrumbs = ({ children, ...props }) => {
 		<Box as="nav" aria-label="breadcrumb" cursor="pointer">
 			<Flex
 				as="ol"
-				display="flex"
 				listStyleType="none"
 				alignItems="center"
 				padding={0}
 				margin={0}
+				whiteSpace="nowrap"
 				{...props}
 			>
 				<Box as="span" marginRight={3} marginBottom={1.5} fontSize="3xl">


### PR DESCRIPTION
- Issue: https://git.chen.so/tina-next-ts/i/c5e14d1619ab76a8b788b51e06219e339b85f7a9
- Patch: https://git.chen.so/tina-next-ts/p/ddb7b60aed348694ea901f8616a40fb14b27feda
- https://github.com/Chen-Software/tina-next-ts/pull/110